### PR TITLE
Add dependency status image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Squeel [![Build Status](https://secure.travis-ci.org/ernie/squeel.png)](http://travis-ci.org/ernie/squeel)
+# Squeel [![Build Status](https://secure.travis-ci.org/ernie/squeel.png)](http://travis-ci.org/ernie/squeel) [![Dependency Status](https://gemnasium.com/ernie/squeel.png)](https://gemnasium.com/ernie/squeel)
 
 Squeel lets you write your ActiveRecord queries with with fewer strings, and more Ruby,
 by making the ARel awesomeness that lies beneath ActiveRecord more accessible.


### PR DESCRIPTION
This helps keep your gem dependencies up to date with the latest versions. In Squeel's case, the faker dependency needs updating and I'd recommend loosening development dependencies to fuzzy matching on the minor version, i.e. `s.add_development_dependency 'rspec', '~> 2.8'`.
