### PR TITLE
build_arel should respect uniq_value

### DIFF
--- a/lib/squeel/adapters/active_record/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/relation_extensions.rb
@@ -102,7 +102,8 @@ module Squeel
           arel.order(*order) unless order.empty?
 
           build_select(arel, attribute_viz.accept(@select_values.uniq))
-
+          
+          arel.distinct(@uniq_value)
           arel.from(@from_value) if @from_value
           arel.lock(@lock_value) if @lock_value
 


### PR DESCRIPTION
Rails 3.2 handles uniq differently from before, including a change to build_arel.  The monkeypatch version in squeel should incorporate this change.  I _think_ this breaks bc with 3.1, but current implementation breaks 3.2.
