### PR TITLE
Fix missing loading ActiveSupport extensions of Module

### DIFF
--- a/lib/squeel/nodes/join.rb
+++ b/lib/squeel/nodes/join.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module'
+
 module Squeel
   module Nodes
     # A node representing a joined association

--- a/lib/squeel/nodes/key_path.rb
+++ b/lib/squeel/nodes/key_path.rb
@@ -1,5 +1,6 @@
 require 'squeel/nodes/operators'
 require 'squeel/nodes/predicate_operators'
+require 'active_support/core_ext/module'
 
 module Squeel
   module Nodes


### PR DESCRIPTION
When I used Squeel with Padrino, I caught following exception.

```
undefined method `delegate' for Squeel::Nodes::Join:Class
/Users/aereal/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/squeel-0.9.5/lib/squeel/nodes/join.rb:9:in `<class:Join>'
/Users/aereal/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/squeel-0.9.5/lib/squeel/nodes/join.rb:4:in `<module:Nodes>'
/Users/aereal/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/squeel-0.9.5/lib/squeel/nodes/join.rb:2:in `<module:Squeel>'
/Users/aereal/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/squeel-0.9.5/lib/squeel/nodes/join.rb:1:in `<top (required)>'
/Users/aereal/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/squeel-0.9.5/lib/squeel/nodes.rb:19:in `require'
/Users/aereal/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/squeel-0.9.5/lib/squeel/nodes.rb:19:in `<top (required)>'
/Users/aereal/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/squeel-0.9.5/lib/squeel.rb:25:in `require'
/Users/aereal/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/squeel-0.9.5/lib/squeel.rb:25:in `<top (required)>'
```

This means lib/squeel/nodes/join.rb cannot load ActiveSupport extensions of Module.
I greped and found missing loading it in lib/squeel/nodes/key_path.rb.
