### PR TITLE
Proof of concept: Value literals

### DIFF
--- a/lib/squeel/dsl.rb
+++ b/lib/squeel/dsl.rb
@@ -89,6 +89,10 @@ module Squeel
       Nodes::Sifter.new name.to_sym, args
     end
 
+    def to_s(string)
+      Nodes::String.new(string)
+    end
+
     # Node generation inside DSL blocks.
     #
     # @overload node_name

--- a/lib/squeel/nodes.rb
+++ b/lib/squeel/nodes.rb
@@ -12,6 +12,7 @@ require 'squeel/nodes/aliasing'
 require 'squeel/nodes/ordering'
 
 require 'squeel/nodes/literal'
+require 'squeel/nodes/string'
 require 'squeel/nodes/stub'
 require 'squeel/nodes/key_path'
 require 'squeel/nodes/sifter'

--- a/lib/squeel/nodes/string.rb
+++ b/lib/squeel/nodes/string.rb
@@ -1,0 +1,15 @@
+module Squeel
+  module Nodes
+    class String
+      include PredicateMethods
+
+      def initialize(string)
+        @instance = string
+      end
+
+      def to_s
+        @instance
+      end
+    end
+  end
+end

--- a/lib/squeel/visitors/predicate_visitation.rb
+++ b/lib/squeel/visitors/predicate_visitation.rb
@@ -45,6 +45,8 @@ module Squeel
         attribute = case o.expr
         when Nodes::Stub, Nodes::Function, Nodes::Literal, Nodes::Grouping
           visit(o.expr, parent)
+        when Nodes::String
+          o.expr.to_s
         else
           contextualize(parent)[o.expr]
         end
@@ -86,8 +88,10 @@ module Squeel
         elsif array.include? nil
           array = array.compact
           array.empty? ? attribute.eq(nil) : attribute.in(array).or(attribute.eq nil)
-        else
+        elsif attribute.respond_to?(:in)
           attribute.in array
+        else
+          Arel::Nodes::In.new(attribute, array)
         end
       end
 


### PR DESCRIPTION
It bothered me a lot that you can't do something like this in Squeel.

``` ruby
Model.where{"bob".in [ foo, bar, baz ]}
```

I'm guessing this is because you didn't want to pollute the string class, which is fair enough, but I felt there should be a compromise because the alternative isn't very nice.

``` ruby
t = Model.arel_table
Model.where(Arel::Nodes::In.new("bob", [ t[:foo], t[:bar], t[:baz] ])
```

I figured that all you need to do is wrap the string in some dummy class so I quickly knocked up a proof of concept. Now you can do this.

``` ruby
Model.where{to_s("bob").in [ foo, bar, baz ]}
```

I obviously don't expect you to merge this as-is, I just wanted to know your thoughts about whether it would be worth expanding upon. The same trick could be applied to other core types like integers and floats. In fact, you may not even need separate classes for these, a single Squeel::Nodes::ValueLiteral class might be sufficient as long as Arel knows what to do the underlying instance.
