### PR TITLE
Count * after more than one field were selected

### DIFF
--- a/lib/squeel/adapters/active_record/4.0/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.0/relation_extensions.rb
@@ -120,40 +120,6 @@ module Squeel
             end
           }
         end
-
-        # So, building a select for a count query in Active Record is
-        # pretty heavily dependent on select_values containing strings.
-        # I'd initially expected that I could just hack together a fix
-        # to select_for_count and everything would fall in line, but
-        # unfortunately, pretty much everything from that point on
-        # in ActiveRecord::Calculations#perform_calculation expects
-        # the column to be a string, or at worst, a symbol.
-        #
-        # In the long term, I would like to refactor the code in
-        # Rails core, but for now, I'm going to settle for this hack
-        # that tries really hard to coerce things to a string.
-        def select_for_count
-          visited_values = select_visit(select_values.uniq)
-          if visited_values.any?
-            string_values = visited_values.map { |value|
-              case value
-              when String
-                value
-              when Symbol
-                value.to_s
-              when Arel::Attributes::Attribute
-                join_name = value.relation.table_alias || value.relation.name
-                "#{connection.quote_table_name join_name}.#{connection.quote_column_name value.name}"
-              else
-                value.respond_to?(:to_sql) ? value.to_sql : value
-              end
-            }
-            string_values.join(', ')
-          else
-            :all
-          end
-        end
-
       end
     end
   end

--- a/lib/squeel/adapters/active_record/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/relation_extensions.rb
@@ -99,6 +99,8 @@ module Squeel
             end
 
             str_select if str_select && str_select !~ /[,*]/
+          else
+            :all
           end
         end
 

--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -389,6 +389,10 @@ module Squeel
             expect { people.first.name }.to raise_error ActiveModel::MissingAttributeError
           end
 
+          it 'works with multiple fields in select' do
+            Article.select("title, body").count.should eq 51
+          end
+
           it 'allows a function in the select values via Symbol#func' do
             relation = Person.select(:max.func(:id).as('max_id'))
             relation.first.max_id.should eq 332


### PR DESCRIPTION
I am using ActiveRecord 4.0 and noticed that some of my queries failed due to problems in calling COUNT function:

```
2.0.0p0 :001 > Organization.select("id, name").count
   (0.5ms)  SELECT COUNT(id, name) FROM "organizations"
PG::UndefinedFunction: ERROR:  function count(integer, character varying) does not exist
LINE 1: SELECT COUNT(id, name) FROM "organizations"
```

I've created patch to use existing correct implementation of method `select_for_count` from parent module `RelationExtensions` and added few lines to make it work similar to its fresh analogue in rails
https://github.com/rails/rails/commit/648afea0e4addcaaf6da31cba78b94d7681706a4
