### PR TITLE
Bug: Rails 4 order hashes fail inside a has_many.

### DIFF
--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -657,6 +657,15 @@ module Squeel
             end
           end
 
+          it 'allows AR 4.0-style hash options inside an association' do
+            if activerecord_version_at_least '4.0.0'
+              block = Person.first.articles_with_order
+              block.to_sql.should match /ORDER BY "articles"\."title" DESC/
+            else
+              pending 'Not required in AR versions < 4.0.0'
+            end
+          end
+
           it 'allows ordering by an attributes of a joined table' do
             relation = Article.joins(:person).order { person.id.asc }
             relation.to_sql.should match /ORDER BY "people"\."id" ASC/

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -9,6 +9,8 @@ class Person < ActiveRecord::Base
     has_many   :article_comments_with_first_post,
       lambda { where :body => 'first post' },
       :through => :articles, :source => :comments
+    has_many   :articles_with_order, lambda { order :title => :desc },
+      :class_name => 'Article'
   else
     has_many   :articles_with_condition, :conditions => {:title => 'Condition'},
       :class_name => 'Article'


### PR DESCRIPTION
In Rails 4, if you give a has_many an order using a hash to specify the sort direction, it's misinterpreted:

``` ruby
class Person < ActiveRecord::Base
  has_many :articles_with_order, lambda { order :title => :desc },
    :class_name => 'Article'
end
```

``` ruby
Person.first.articles_with_order.to_sql
# => SELECT "articles".* FROM "articles"  WHERE "articles"."person_id" = ?  ORDER BY "title"."desc"
```

A failing spec is attached. It demonstrates the issue, though it probably needs a little rewriting.
