### PR TITLE
Bug: scope_for_create with polymorphic association

### DIFF
--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -800,6 +800,17 @@ module Squeel
             end
           end
 
+          it 'creates new records with values from a polymorphic association' do
+            if activerecord_version_at_least '4.0.0'
+              article = Article.first
+              note = Note.where(notable: article).new
+              note.notable_id.should eq article.id
+              note.notable_type.should eq 'Article'
+            else
+              pending 'Not required pre-4.0'
+            end
+          end
+
         end
 
         describe '#as' do


### PR DESCRIPTION
In a `#where` specifying a value for a polymorphic association, the `_type` is
not set in the `#scope_for_create` attributes. In vanilla AR4, `_type` and `_id`
are both set.

Failing spec is attached.
