### PR TITLE
Specifying `:uniq => true` has been deprecated by Rails. Use a scope with uniq instead.

### DIFF
--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -73,7 +73,7 @@ class Article < ActiveRecord::Base
   has_and_belongs_to_many :tags
   has_many :notes, :as => :notable
   has_many :commenters, :through => :comments, :source => :person
-  has_many :uniq_commenters, :through => :comments, :source => :person, :uniq => true
+  has_many :uniq_commenters, -> {uniq}, :through => :comments, :source => :person
 end
 
 class Comment < ActiveRecord::Base


### PR DESCRIPTION
Specifying `:uniq => true` has for has_many been deprecated by Rails. Use a scope with uniq instead.
