### PR TITLE
Add a keyword node to use "*" and "not" in Squeel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Size method can return the result correctly when grouping by the column of a
   joined table. Fixes #286
+* Add a keyword node to use * and not in Squeel. Fix #17, #182.
 
 ## 1.2.1 (2014-07-18)
 

--- a/lib/squeel/nodes.rb
+++ b/lib/squeel/nodes.rb
@@ -12,6 +12,7 @@ require 'squeel/nodes/operators'
 require 'squeel/nodes/predicate_operators'
 require 'squeel/nodes/aliasing'
 require 'squeel/nodes/ordering'
+require 'squeel/nodes/keyword'
 
 require 'squeel/nodes/literal'
 require 'squeel/nodes/stub'

--- a/lib/squeel/nodes/function.rb
+++ b/lib/squeel/nodes/function.rb
@@ -8,6 +8,7 @@ module Squeel
       include Operators
       include Ordering
       include Aliasing
+      include Keyword
 
       alias :== :eq
       alias :'^' :not_eq
@@ -31,7 +32,7 @@ module Squeel
       # @param [Symbol] name The function name
       # @param [Array] args The array of arguments to pass to the function.
       def initialize(function_name, args)
-        @function_name, @args = function_name, args
+        @function_name, @args = translate_keyword(function_name), args
       end
 
       # expand_hash_conditions_for_aggregates assumes our hash keys can be

--- a/lib/squeel/nodes/keyword.rb
+++ b/lib/squeel/nodes/keyword.rb
@@ -1,0 +1,15 @@
+module Squeel
+  module Nodes
+    module Keyword
+
+      KEYWORDS = {
+        :_star => :*,
+        :_not  => :NOT
+      }
+
+      def translate_keyword(method_id)
+        KEYWORDS.fetch(method_id, method_id)
+      end
+    end
+  end
+end

--- a/lib/squeel/nodes/stub.rb
+++ b/lib/squeel/nodes/stub.rb
@@ -8,6 +8,7 @@ module Squeel
       include Operators
       include Aliasing
       include Ordering
+      include Keyword
 
       alias :== :eq
       alias :'^' :not_eq
@@ -34,7 +35,7 @@ module Squeel
       # Create a new Stub.
       # @param [Symbol] symbol The symbol that this Stub contains
       def initialize(symbol)
-        @symbol = symbol
+        @symbol = translate_keyword(symbol)
       end
 
       # Object comparison

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -113,7 +113,7 @@ class Membership < ActiveRecord::Base
     default_scope where(active: true)
   end
 
-  before_save :set_active
+  before_create :set_active
 
   def set_active
     self.active = true


### PR DESCRIPTION
Hi @ernie,

In #17, #182, people mentioned problems about using some keywords in SQL, it's hard to implement in Ruby, @unrealhoang said if it had a possibility to use a trailing character before these keywords.

I think things should like :

``` ruby
# _* is invalid...
Person.select{articles._star}.joins{articles}
Person.select{_star}
Person.where{(id == 1) | _not(exists(Article.where{person_id == people.id}))}
```

But I'm not sure that things I changed was proper. So it's very glad to hear your suggestions :smile:
