### PR TITLE
undefined method `preloaded_records' for :relation:Symbol

### DIFF
--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -339,6 +339,14 @@ module Squeel
             relation.debug_sql.should match /SELECT #{Q}notes#{Q}.* FROM #{Q}notes#{Q} LEFT OUTER JOIN #{Q}articles#{Q} ON #{Q}articles#{Q}.#{Q}id#{Q} = #{Q}notes#{Q}.#{Q}notable_id#{Q} AND #{Q}notes#{Q}.#{Q}notable_type#{Q} = 'Article' LEFT OUTER JOIN #{Q}people#{Q} ON #{Q}people#{Q}.#{Q}id#{Q} = #{Q}articles#{Q}.#{Q}person_id#{Q} LEFT OUTER JOIN #{Q}people#{Q} #{Q}children_people#{Q} ON #{Q}children_people#{Q}.#{Q}parent_id#{Q} = #{Q}people#{Q}.#{Q}id#{Q} WHERE #{Q}children_people#{Q}.#{Q}name#{Q} = 'Ernie'/
           end
 
+          it 'eager loads has_and_belongs_to_many' do
+            relation = Article.includes{tags}.to_a
+          end
+
+          it 'eager loads `has_many through:`' do
+            relation = Person.includes{authored_article_comments}.to_a
+          end
+
         end
 
         describe '#preload' do


### PR DESCRIPTION
In rails 4.1.4, using squeel@master to eager load a habtm or `has_many through:` results in an error from deep inside the ActiveRecord bowels: `undefined method 'preloaded_records' for :tag:Symbol`.  Looking at adapters/active_record/4.1/preloader_extensions.rb, it seems that preload_with_squeel returns something (the preload keypath as a nested hash) that is nothing like preload_without_squeel (an array of ActiveRecord::Associations::Preloader::BelongsTo or similar).

This PR currently adds two simple failing specs to the squeel suite (at least when run with "RAILS=v4.1.4 AREL=5.0.1").  I will try to dig deeper, but not sure I have the mojo to figure out all of the moving parts.

Full trace from the error:

```
     Failure/Error: relation = Article.includes{tags}.to_a
     NoMethodError:
       undefined method `preloaded_records' for :tag:Symbol
     # activerecord/lib/active_record/associations/preloader/through_association.rb:32:in `each'
     # activerecord/lib/active_record/associations/preloader/through_association.rb:32:in `flat_map'
     # activerecord/lib/active_record/associations/preloader/through_association.rb:32:in `associated_records_by_owner'
     # activerecord/lib/active_record/associations/preloader/has_many_through.rb:8:in `associated_records_by_owner'
     # activerecord/lib/active_record/associations/preloader/collection_association.rb:13:in `preload'
     # activerecord/lib/active_record/associations/preloader/association.rb:20:in `run'
     # activerecord/lib/active_record/associations/preloader.rb:137:in `block (2 levels) in preloaders_for_one'
     # activerecord/lib/active_record/associations/preloader.rb:135:in `each'
     # activerecord/lib/active_record/associations/preloader.rb:135:in `map'
     # activerecord/lib/active_record/associations/preloader.rb:135:in `block in preloaders_for_one'
     # activerecord/lib/active_record/associations/preloader.rb:134:in `each'
     # activerecord/lib/active_record/associations/preloader.rb:134:in `flat_map'
     # activerecord/lib/active_record/associations/preloader.rb:134:in `preloaders_for_one'
     # activerecord/lib/active_record/associations/preloader.rb:106:in `preloaders_on'
     # ./lib/squeel/adapters/active_record/4.1/preloader_extensions.rb:21:in `block in preload_with_squeel'
     # ./lib/squeel/adapters/active_record/4.1/preloader_extensions.rb:20:in `each'
     # ./lib/squeel/adapters/active_record/4.1/preloader_extensions.rb:20:in `preload_with_squeel'
     # activerecord/lib/active_record/relation.rb:610:in `block in exec_queries'
     # activerecord/lib/active_record/relation.rb:609:in `each'
     # activerecord/lib/active_record/relation.rb:609:in `exec_queries'
     # activerecord/lib/active_record/relation.rb:486:in `load'
     # activerecord/lib/active_record/relation.rb:231:in `to_a'
     # ./spec/squeel/adapters/active_record/relation_extensions_spec.rb:343:in `block (3 levels) in <module:ActiveRecord>'
```
