### PR TITLE
Ordering sequence is now correct when chaining multiple order methods in...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix NoMethodError when calling unscope method above Rails 4. By @estum
 * Fix error when including HABTM or HMT associations without eager loading.
   Fixes #326.
+* Ordering sequence is now correct when chaining multiple order methods. Fixes #276.
 
 ## 1.2.1 (2014-07-18)
 

--- a/lib/squeel/adapters/active_record/4.0/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.0/relation_extensions.rb
@@ -160,10 +160,12 @@ module Squeel
 
           # if a symbol is given we prepend the quoted table name
           args = args.map { |arg|
-            arg.is_a?(Symbol) ? "#{quoted_table_name}.#{arg} ASC" : arg
+            arg.is_a?(Symbol) ?
+              Arel::Nodes::Ascending.new(klass.arel_table[arg]) :
+              arg
           }
 
-          self.order_values = args + self.order_values
+          self.order_values += args
           self
         end
 

--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -776,7 +776,6 @@ module Squeel
               if MYSQL_ENV
                 User.first.groups.to_sql.should match /#{Q}memberships#{Q}.#{Q}active#{Q} = 1/
               else
-                puts User.first.groups.to_sql
                 User.first.groups.to_sql.should match /#{Q}memberships#{Q}.#{Q}active#{Q} = 't'/
               end
 
@@ -834,6 +833,11 @@ module Squeel
           it 'allows ordering by an attributes of a joined table' do
             relation = Article.joins(:person).order { person.id.asc }
             relation.to_sql.should match /ORDER BY #{Q}people#{Q}.#{Q}id#{Q} ASC/
+          end
+
+          it 'orders chain in correct sequence' do
+            relation = Article.order {id.asc}.order {title.desc}
+            relation.to_sql.should match /#{Q}articles#{Q}.#{Q}id#{Q} ASC, #{Q}articles#{Q}.#{Q}title#{Q} DESC/
           end
 
         end


### PR DESCRIPTION
... Rails 4.0 stable branch.

Fixes #276.

Example:

``` ruby
Article.order {id.asc}.order {title.desc}.to_sql 
# => SELECT "articles".* FROM "articles" ORDER BY "articles".id ASC,
# => "articles".title DESC
```
