### PR TITLE
broken hash conditions when querying for an activerecord object on a joined table

### DIFF
--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -717,6 +717,13 @@ module Squeel
             Person.first.authored_article_comments.joins(:article).first.should eq Comment.first
           end
 
+          it 'does not break hash conditions that specify the table name' do
+            person = Comment.first.article.person
+            person.should be_present
+            Comment.joins(:article).where(articles: {person_id: person}).should be_present
+            Comment.joins(:article).where(articles: {person: person}).should be_present
+          end
+
           it 'joins polymorphic belongs_to associations' do
             relation = Note.joins{notable(Article)}
             relation.to_sql.should match /#{Q}notes#{Q}.#{Q}notable_type#{Q} = 'Article'/


### PR DESCRIPTION
Not really a pull request, just a test.  Seems like squeel breaks the following expressions:

``` ruby
    Comment.joins(:article).where(articles: {person_id: person})
    Comment.joins(:article).where(articles: {person: person})
```

These will both raise an exception telling us that 'articles' cannot be converted to a class.

The fix looks like it would be pretty involved.  Essentially squeel is trying to replicate AR predicate builder, but it might be better offer using it, and somehow converting the resulting arel back into something it can work with because trying to keep the behavior up to date and matching might be  a pain.
