### PR TITLE
Changed an invalid instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Person.select('"people".*').joins('LEFT OUTER JOIN "articles" ON "articles"."per
 # => SELECT "people".* FROM "people"
 #    LEFT OUTER JOIN "articles" ON "articles"."person_id" = "people"."id"
 #    LEFT OUTER JOIN "comments" ON "comments"."article_id" = "articles"."id"
-#    LEFT OUTER JOIN "people" "people_comments" ON "people_comments"."id" = "comments"."person_id"
+#    LEFT OUTER JOIN "people_comments" ON "people_comments"."id" = "comments"."person_id"
 ```
 
 With a keypath, this would look like:


### PR DESCRIPTION
This example is invalid according to the documentation

http://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-references

"This method only works in conjuction with includes."
