### PR TITLE
Delegate to `visit` instead of calling `.id` directly

### DIFF
--- a/lib/squeel/visitors/predicate_visitor.rb
+++ b/lib/squeel/visitors/predicate_visitor.rb
@@ -21,7 +21,7 @@ module Squeel
         context = contextualize(parent)
         ar_base = o.value
         conditions = [
-          context[association.foreign_key.to_s].send(o.method_name, ar_base.id)
+          context[association.foreign_key.to_s].send(o.method_name, visit(ar_base, parent))
         ]
         if association.options[:polymorphic]
           conditions << [


### PR DESCRIPTION
This is related to #348

Translation of an ActiveRecord::Base object to an integer should be defined once (i.e. in visit_ActiveRecord_base). This makes it easier for the case when a user does not want to query by `id` but some other field, for example `persistent_id`
