### PR TITLE
Fix 4.1 adapter under Rubinius

### DIFF
--- a/lib/squeel/adapters/active_record/4.1/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.1/relation_extensions.rb
@@ -168,18 +168,23 @@ module Squeel
         %w(where having group order).each do |visitor|
           define_method "#{visitor}_visit" do |values|
             join_dependencies = [join_dependency] + stashed_join_dependencies
-            join_dependencies.each do |jd|
+            result = join_dependencies.find do |jd|
               context = Adapters::ActiveRecord::Context.new(jd)
               begin
-                return Visitors.const_get("#{visitor.capitalize}Visitor").new(context).accept!(values)
+                # Don't use return here, it breaks Rubinius 2.3.0.
+                break Visitors.const_get("#{visitor.capitalize}Visitor").new(context).accept!(values)
               rescue Adapters::ActiveRecord::Context::NoParentFoundError => e
                 next
               end
             end
 
-            # Fail Safe, call the normal accept method.
-            context = Adapters::ActiveRecord::Context.new(join_dependency)
-            Visitors.const_get("#{visitor.capitalize}Visitor").new(context).accept(values)
+            if result.nil?
+              # Fail Safe, call the normal accept method.
+              context = Adapters::ActiveRecord::Context.new(join_dependency)
+              Visitors.const_get("#{visitor.capitalize}Visitor").new(context).accept(values)
+            else
+              result
+            end
           end
         end
 


### PR DESCRIPTION
Calling return inside a block under Rubinius results in aLocalJumpError, at least with version 2.3.0. This is probably a Rubinius bug but it is easy enough to work around it here.

I am making the assumption that `accept!` will never return nil. Is that reasonable?

Unfortunately one other spec still fails but I don't think it's Squeel's fault. It's something to do with preloading HABTM associations, possibly caused by the Rubinius implementation of flat_map.
