### PR TITLE
Fix for ActiveRecord 4.2 and Arel changes

### DIFF
--- a/lib/squeel/adapters/active_record.rb
+++ b/lib/squeel/adapters/active_record.rb
@@ -1,5 +1,5 @@
 case ActiveRecord::VERSION::MAJOR
-when 3, 4, 5
+when 3, 4
   ActiveRecord::Relation.send :include, Squeel::Nodes::Aliasing
   require 'squeel/adapters/active_record/base_extensions'
 

--- a/lib/squeel/adapters/active_record.rb
+++ b/lib/squeel/adapters/active_record.rb
@@ -1,5 +1,5 @@
 case ActiveRecord::VERSION::MAJOR
-when 3, 4
+when 3, 4, 5
   ActiveRecord::Relation.send :include, Squeel::Nodes::Aliasing
   require 'squeel/adapters/active_record/base_extensions'
 

--- a/lib/squeel/adapters/active_record/4.1/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.1/relation_extensions.rb
@@ -94,14 +94,19 @@ module Squeel
           arel.distinct(distinct_value)
           arel.from(build_from) if from_value
           arel.lock(lock_value) if lock_value
-
-          # Reorder bind indexes when joins or subqueries include more bindings.
-          # Special for PostgreSQL
-          if arel.bind_values.any? || bind_values.size > 1
-            bvs = arel.bind_values + bind_values
-            arel.ast.grep(Arel::Nodes::BindParam).each_with_index do |bp, i|
-              column = bvs[i].first
-              bp.replace connection.substitute_at(column, i)
+          
+          # Check if we are dealing with a version prior to Arel commit 590c784a30b13153667f8db7915998d7731e24e5
+          # where BindParam is changed from SqlLiteral to a Node
+          # https://github.com/rails/arel/commit/590c784a30b13153667f8db7915998d7731e24e5
+          if Arel::Nodes::BindParam.class.is_a? Arel::Nodes::SqlLiteral
+            # Reorder bind indexes when joins or subqueries include more bindings.
+            # Special for PostgreSQL
+            if arel.bind_values.any? || bind_values.size > 1
+              bvs = arel.bind_values + bind_values
+              arel.ast.grep(Arel::Nodes::BindParam).each_with_index do |bp, i|
+                column = bvs[i].first
+                bp.replace connection.substitute_at(column, i)
+              end
             end
           end
 

--- a/lib/squeel/adapters/active_record/4.2/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.2/relation_extensions.rb
@@ -89,7 +89,12 @@ module Squeel
         def expand_attrs_from_hash(opts)
           opts = ::ActiveRecord::PredicateBuilder.resolve_column_aliases(klass, opts)
           
-          tmp_opts, bind_values = create_binds(opts)
+          bind_args = [opts]
+          # Active Record 4.1 compatibility
+          # (for commits before 08579e4078454c6058f1289b58bf5bfa26661376 - https://github.com/rails/rails/commit/08579e4078454c6058f1289b58bf5bfa26661376)
+          bind_args << bind_values.length if method(:create_binds).arity > 1
+          tmp_opts, bind_values = create_binds(*bind_args)
+
           self.bind_values += bind_values
 
           attributes = @klass.send(:expand_hash_conditions_for_aggregates, tmp_opts)

--- a/lib/squeel/adapters/active_record/4.2/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.2/relation_extensions.rb
@@ -88,9 +88,8 @@ module Squeel
 
         def expand_attrs_from_hash(opts)
           opts = ::ActiveRecord::PredicateBuilder.resolve_column_aliases(klass, opts)
-
-          bv_len = bind_values.length
-          tmp_opts, bind_values = create_binds(opts, bv_len)
+          
+          tmp_opts, bind_values = create_binds(opts)
           self.bind_values += bind_values
 
           attributes = @klass.send(:expand_hash_conditions_for_aggregates, tmp_opts)


### PR DESCRIPTION
The ActiveRecord fix is pretty straightforward.

In the new Arel version (commit where it breaks is mentioned), the `BindParam` class now subclasses `Node` instead of `SqlLiteral` which means that none of the String methods will work. It's unclear if the needed reordering for Postgres (mentioned in the comment) is now handled by Arel, or if that replacement needs to occur elsewhere.