### PR TITLE
Fix NoMethodError for Arel::Nodes::BindParam

### DIFF
--- a/lib/squeel/adapters/active_record/4.2/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.2/relation_extensions.rb
@@ -103,6 +103,7 @@ module Squeel
             [name, binds.fetch(name.to_s) {
               case where.right
               when Array then where.right.map(&:val)
+              when Arel::Nodes::Unary then where.right.value
               else
                 where.right.val
               end

--- a/lib/squeel/version.rb
+++ b/lib/squeel/version.rb
@@ -1,3 +1,3 @@
 module Squeel
-  VERSION = '1.2.2'
+  VERSION = '1.2.3'
 end

--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -1062,7 +1062,21 @@ module Squeel
               raise ::ActiveRecord::Rollback
             end
           end
-
+          
+          it 'creates new records with equality predicates from has_many polymorphic associations' do
+            if activerecord_version_at_least '4.2.0'
+              Payment.transaction do
+                seat = Seat.first
+                order_item = seat.order_items.create(:quantity => 0)
+                order_item.should be_persisted
+                order_item.orderable_id.should eq seat.id
+                order_item.orderable_type.should eq 'Seat'
+                raise ::ActiveRecord::Rollback
+              end
+            else
+              pending 'Not required in AR versions < 4.2.0'
+            end              
+          end
         end
 
         describe '#where_unscoping' do


### PR DESCRIPTION
Fix raising "NoMethodError: undefined method val for Arel::Nodes::BindParam" in `where_values_hash_with_squeel` method. 
I found that it tries `Arel::Nodes::Unary` instance to call missing `val` method instead of `value` (https://github.com/rails/arel/blob/master/lib/arel/nodes/unary.rb). 
Bug detected when trying to build new record on `has_many` polymorphic association.

Tested only with postgresql, sorry.