### PR TITLE
Fixes #379

### DIFF
--- a/squeel.gemspec
+++ b/squeel.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', '>= 3.0'
   s.add_dependency 'activesupport', '>= 3.0'
-  s.add_dependency 'polyamorous', '~> 1.1.0'
+  s.add_dependency 'polyamorous', '~> 1.2.0'
   s.add_development_dependency 'rspec', '~> 2.6.0'
   s.add_development_dependency 'faker', '~> 0.9.5'
   s.add_development_dependency 'sqlite3', '~> 1.3.3'


### PR DESCRIPTION
Since polyamorous 1.1.0 [differs from 1.2.0](https://github.com/activerecord-hackery/polyamorous/commit/ca95023c581e8a1fdf87a042953a71e0aa297691) only by the version number and the README file, it's only natural to simply change the version number.