### PR TITLE
Fix where_unscoping on 4.0, 4.1, 4.2

### DIFF
--- a/lib/squeel/adapters/active_record/4.0/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.0/relation_extensions.rb
@@ -32,6 +32,7 @@ module Squeel
 
         def where_unscoping(target_value)
           target_value = target_value.to_s
+          where_values.flatten!
 
           where_values.reject! do |rel|
             case rel

--- a/lib/squeel/adapters/active_record/4.1/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.1/relation_extensions.rb
@@ -44,12 +44,10 @@ module Squeel
 
         def where_unscoping(target_value)
           target_value = target_value.to_s
+          where_values.flatten!
 
           where_values.reject! do |rel|
             case rel
-            when Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality, Arel::Nodes::NotEqual
-              subrelation = (rel.left.kind_of?(Arel::Attributes::Attribute) ? rel.left : rel.right)
-              subrelation.name == target_value
             when Hash
               rel.stringify_keys.has_key?(target_value)
             when Squeel::Nodes::Predicate
@@ -57,7 +55,7 @@ module Squeel
             end
           end
 
-          bind_values.reject! { |col,_| col.name == target_value }
+          super
         end
 
         def reverse_sql_order(order_query)

--- a/lib/squeel/adapters/active_record/4.2/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/4.2/relation_extensions.rb
@@ -7,6 +7,21 @@ module Squeel
 
         undef_method 'to_sql_with_binding_params'
 
+        def where_unscoping(target_value)
+          target_value = target_value.to_s
+
+          self.where_values = where_values.flatten.reject do |rel|
+            case rel
+            when Hash
+              rel.stringify_keys.has_key?(target_value)
+            when Squeel::Nodes::Predicate
+              rel.expr.symbol.to_s == target_value if rel.expr.respond_to?(:symbol)
+            end
+          end
+
+          super
+        end
+
         attr_accessor :reverse_order_value
         private :reverse_order_value, :reverse_order_value=
 

--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -1068,16 +1068,12 @@ module Squeel
         describe '#where_unscoping' do
 
           it "doesn't ruin everything when predicate expression in where_values doesn't respond to :symbol method" do
-            unless activerecord_version_at_least '4.2.0'
-              if activerecord_version_at_least '4.0.0'
-                order_items = OrderItem.where{quantity == 0}.where{unit_price / 2 == 5}
-                expect { order_items.unscope(where: :quantity) }.should_not raise_error
-                order_items.to_sql.should_not match /#{Q}order_items#{Q}.#{Q}quantity#{Q} = 0/
-              else
-                pending 'Unsupported on AR versions < 4.0.0'
-              end
+            if activerecord_version_at_least '4.0.0'
+              order_items = OrderItem.where{quantity == 0}.where{unit_price / 2 == 5}
+              expect { order_items.unscope!(where: :quantity) }.should_not raise_error
+              order_items.to_sql.should_not match /#{Q}order_items#{Q}.#{Q}quantity#{Q} = 0/
             else
-              pending 'Not required in AR versions > 4.2.0'
+              pending 'Unsupported on AR versions < 4.0.0'
             end
           end
 

--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -1067,6 +1067,10 @@ module Squeel
 
         describe '#where_unscoping' do
 
+          it "isn't broken" do
+            OrderItem.where(:quantity => 0).unscope(:where => :quantity).where_values.should be_empty
+          end
+
           it "doesn't ruin everything when predicate expression in where_values doesn't respond to :symbol method" do
             if activerecord_version_at_least '4.0.0'
               order_items = OrderItem.where{quantity == 0}.where{unit_price / 2 == 5}


### PR DESCRIPTION
Believe it or not, basic `unscope` functionality was broken. I don't know how but With Squeel in play, `where_values` somehow becomes a nested array. Flattening it first fixes the issue.

I have adjusted the 4.1 override to use `super` so that less code is duplicated. This isn't possible for 4.0. I have added a new override for 4.2 because `where_values` should not be mutated in that version.