### PR TITLE
Remove where clause grouping from RelationExtensions#collapse_wheres

### DIFF
--- a/lib/squeel/adapters/active_record/relation_extensions.rb
+++ b/lib/squeel/adapters/active_record/relation_extensions.rb
@@ -270,9 +270,7 @@ module Squeel
           wheres = Array(wheres)
           binaries = wheres.grep(Arel::Nodes::Binary)
 
-          groups = binaries.group_by {|b| [b.class, b.left]}
-
-          arel.where(Arel::Nodes::And.new(groups.map{|_, bins| bins}.flatten)) if groups.any?
+          arel.where(Arel::Nodes::And.new(binaries)) if binaries.any?
 
           (wheres - binaries).each do |where|
             where = Arel.sql(where) if String === where

--- a/spec/squeel/adapters/active_record/relation_extensions_spec.rb
+++ b/spec/squeel/adapters/active_record/relation_extensions_spec.rb
@@ -1000,6 +1000,15 @@ module Squeel
 
         end
 
+        describe '#collapse_wheres' do
+
+          it 'does not reorder binaries' do
+            relation = Cat.where(hair_type: "short").where(name: "Crookshanks").where(hair_type: "long")
+            relation.to_sql.should eq "SELECT #{Q}cats#{Q}.* FROM #{Q}cats#{Q} WHERE #{Q}cats#{Q}.#{Q}hair_type#{Q} = 'short' AND #{Q}cats#{Q}.#{Q}name#{Q} = 'Crookshanks' AND #{Q}cats#{Q}.#{Q}hair_type#{Q} = 'long'"
+          end
+
+        end
+
         describe '#debug_sql' do
 
           it 'returns the query that would be run against the database, even if eager loading' do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -223,3 +223,5 @@ class Models
   end
 end
 
+class Cat < ActiveRecord::Base
+end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -163,6 +163,10 @@ silence_stream(STDOUT) do
 
     end
 
+    create_table :cats do |t|
+      t.string :name
+      t.string :hair_type
+    end
   end
 end
 


### PR DESCRIPTION
When a column is referenced in more than one where clause, the group_by and subsequent re-ordering of columns can cause the wrong bound values to be associated with columns. The columns are reordered, but the bound values are attached in their original order.

It looks like the current collapse_wheres in Squeel is based on the one from [Active Record 3](https://github.com/rails/rails/blob/3-0-stable/activerecord/lib/active_record/relation/query_methods.rb#L199)

I am unsure why the columns were grouped originally, but this now results in incorrect behavior under certain circumstances. You can see that in [Active Record 4's version of this method](https://github.com/rails/rails/blob/4-0-stable/activerecord/lib/active_record/relation/query_methods.rb#L890), where clauses are no longer grouped.

My change removes the grouping and reordering.

With the original collapse_wheres, you can see the spec I have added failing:

``` ruby
it 'does not reorder binaries' do
  relation = Cat.where(hair_type: "short").where(name: "Crookshanks").where(hair_type: "long")
  relation.to_sql.should eq "SELECT #{Q}cats#{Q}.* FROM #{Q}cats#{Q} WHERE #{Q}cats#{Q}.#{Q}hair_type#{Q} = 'short' AND #{Q}cats#{Q}.#{Q}name#{Q} = 'Crookshanks' AND #{Q}cats#{Q}.#{Q}hair_type#{Q} = 'long'"
end
```

```
Failures:

  1) Squeel::Adapters::ActiveRecord::RelationExtensions#collapse_wheres does not reorder binaries
     Failure/Error: relation.to_sql.should eq "SELECT #{Q}cats#{Q}.* FROM #{Q}cats#{Q} WHERE #{Q}cats#{Q}.#{Q}hair_type#{Q} = 'short' AND #{Q}cats#{Q}.#{Q}name#{Q} = 'Crookshanks' AND #{Q}cats#{Q}.#{Q}hair_type#{Q} = 'long'"

       expected "SELECT \"cats\".* FROM \"cats\" WHERE \"cats\".\"hair_type\" = 'short' AND \"cats\".\"name\" = 'Crookshanks' AND \"cats\".\"hair_type\" = 'long'"
            got "SELECT \"cats\".* FROM \"cats\" WHERE \"cats\".\"hair_type\" = 'short' AND \"cats\".\"hair_type\" = 'Crookshanks' AND \"cats\".\"name\" = 'long'"

       (compared using ==)
     # /Users/farr/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-expectations-2.6.0/lib/rspec/expectations/fail_with.rb:29:in `fail_with'
     # /Users/farr/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-expectations-2.6.0/lib/rspec/expectations/handler.rb:19:in `handle_matcher'
     # /Users/farr/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rspec-expectations-2.6.0/lib/rspec/expectations/extensions/kernel.rb:27:in `should'
     # ./spec/squeel/adapters/active_record/relation_extensions_spec.rb:1007:in `block (3 levels) in <module:ActiveRecord>'

Finished in 1.43 seconds
870 examples, 1 failure, 7 pending

Failed examples:

rspec ./spec/squeel/adapters/active_record/relation_extensions_spec.rb:1005 # Squeel::Adapters::ActiveRecord::RelationExtensions#collapse_wheres does not reorder binaries
~/projects/squeel <master> &
```

Note that as the query was built, it is trying to use "long" as the cat's name instead of "Crookshanks".
